### PR TITLE
change font url to relative path

### DIFF
--- a/css/paris_clean.css
+++ b/css/paris_clean.css
@@ -1,6 +1,6 @@
 @font-face {
   font-family: "Caslon Book BE";
-  src: url("apreus.github.io/paris-project/fonts/webFonts/BertholdCaslonBookRegular/font.woff2");
+  src: url("../fonts/webFonts/BertholdCaslonBookRegular/font.woff2");
 }
 
 body {


### PR DESCRIPTION
This absolute path URL (apreus.github.io/paris-project/fonts/webFonts/BertholdCaslonBookRegular/font.woff2) was somehow becoming this URL (https://apreus.github.io/paris-project/css/apreus.github.io/paris-project/fonts/webFonts/BertholdCaslonBookRegular/font.woff2). 

The relative path seems to work better